### PR TITLE
Fixed About page margins and added social media icon colours on hover

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,7 +47,7 @@
     <div class="container-fluid hero-container  about-container">
         <div class="opaque-overlay">&nbsp;</div>
         <section class="row g-5 about-section">
-            <div class="col-12">
+            <div class="col-12 about-paragraph">
                 <h2 class="about-h2">What is this site about?</h2>
                 <p>
                     This is a one-stop site for those wishing to find a career in software or web development, within
@@ -60,8 +60,8 @@
                     career support and free tools.
                 </p>
             </div>
-            <div class="col-12">
-                <h2>Who are we?</h2>
+            <div class="col-12 about-paragraph">
+                <h2 class="about-h2">Who are we?</h2>
                 <p>
                     We are LevelCoder, a group of tech lovers working and studying within a 50 mile radius of Birmingham
                     city centre.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -55,8 +55,33 @@ Different coloured text surrounding the main heading gives a friendly feel*/
 all anchor tags have a bar above the text*/
 a {
     text-decoration: overline;
+    transition: all 0.2s;
 }
 
+/* added individual color changes for onHover on social media icons - not sure if keeping, so using !important for now */
+.fa-brands {
+    transition: color 0.2s;
+}
+
+i.fa-twitter:hover {
+    color: #1DA1F2 !important;
+}
+
+i.fa-github:hover {
+    color: black !important;
+}
+
+i.fa-linkedin-in:hover {
+    color: #0072b1 !important;
+}
+
+i.fa-instagram:hover {
+    color: hotpink !important;
+}
+
+i.fa-facebook:hover {
+    color: #1877F2 !important;
+}
 /*The hero image covers the viewport and has an opaque layer on top.
 This makes the image a bit darker, in order to contrast better with any overlaid text.
 This code came from the Code Institute Whiskey Drop walkthrough lessons.
@@ -163,8 +188,9 @@ hr {
     height: auto;
 }
 
+/* 1rem top/bottom padding, 0 horizontal padding for h2 titles */
 .about-h2 {
-    padding-top: 5rem;
+    padding: 1rem 0;
 }
 
 .about-section {
@@ -177,6 +203,13 @@ hr {
 
 .about-section h2 {
     font-weight: 300;
+}
+
+/* even out spacing for About paragraphs - main justification for adding background color different from the colour scheme
+ is that the text is a bit difficult to read  */
+.about-paragraph {
+    border-radius: 20px;
+    background: rgba(0,0,0,0.5);
 }
 
 footer {
@@ -201,4 +234,16 @@ footer p {
 
 footer i:hover {
     color: #ff8c00;
+    transition: all 0.2s;
+}
+
+/* Fix mobile spacing for the About page */
+@media screen and (max-width: 768px) {
+    .about-paragraph:first-of-type {
+        margin-top: 9rem;
+    }
+
+    .about-paragraph:last-of-type {
+        margin-bottom: 3rem;
+    }
 }


### PR DESCRIPTION
Hi there!

I've added some small changes to the About page so that the About page should still work on mobile using a media query, but when viewed on a PC it won't have the huge margin on top. Also I've added a darker background on the About paragraphs at 50% opacity for readability because the background makes it a bit difficult to read.

I've also added some small CSS rules for the social media icons so when you hover over them, they'll use the respective colour for their regular logo. I think it should still be evident that you can click on them to get to the link though. That and I've added a quick transition property to links so the animation is smoothed out a bit.